### PR TITLE
Remove the $youtube service; allow for multiple on one page

### DIFF
--- a/src/angular-youtube-embed.js
+++ b/src/angular-youtube-embed.js
@@ -1,140 +1,19 @@
+/* global YT */
 angular.module('youtube-embed', ['ng'])
-.service('$youtube', ['$window', '$rootScope', function ($window, $rootScope) {
+.directive('youtubeVideo', ['$rootScope', '$window', function ($rootScope, $window) {
+    var uniqId = 1;
+
     // adapted from http://stackoverflow.com/a/5831191/1614967
     var youtubeRegexp = /https?:\/\/(?:[0-9A-Z-]+\.)?(?:youtu\.be\/|youtube(?:-nocookie)?\.com\S*[^\w\s-])([\w-]{11})(?=[^\w-]|$)(?![?=&+%\w.-]*(?:['"][^<>]*>|<\/a>))[?=&+%\w.-]*/ig;
     var timeRegexp = /t=(\d+)[ms]?(\d+)?s?/;
 
-    function contains (str, substr) {
+    function contains(str, substr) {
         return (str.indexOf(substr) > -1);
-    }
-
-    var service = {
-        // Frame is ready
-        ready: false,
-
-        // Element id for player
-        playerId: null,
-
-        // Player currently in use
-        player: null,
-
-        // Current video id
-        videoId: null,
-
-        // Size
-        playerHeight: null,
-        playerWidth: null,
-
-        currentState: null,
-
-        setURL: function (url) {
-            service.videoId = service.getIdFromURL(url);
-        },
-
-        getIdFromURL: function (url) {
-            var id = url.replace(youtubeRegexp, '$1');
-
-            if (contains(id, ';')) {
-                var pieces = id.split(';');
-
-                if (contains(pieces[1], '%')) {
-                    // links like this:
-                    // "http://www.youtube.com/attribution_link?a=pxa6goHqzaA&amp;u=%2Fwatch%3Fv%3DdPdgx30w9sU%26feature%3Dshare"
-                    // have the real query string URI encoded behind a ';'.
-                    // at this point, `id is 'pxa6goHqzaA;u=%2Fwatch%3Fv%3DdPdgx30w9sU%26feature%3Dshare'
-                    var uriComponent = decodeURIComponent(id.split(';')[1]);
-                    id = ('http://youtube.com' + uriComponent)
-                            .replace(youtubeRegexp, '$1');
-                } else {
-                    // https://www.youtube.com/watch?v=VbNF9X1waSc&amp;feature=youtu.be
-                    // `id` looks like 'VbNF9X1waSc;feature=youtu.be' currently.
-                    // strip the ';feature=youtu.be'
-                    id = pieces[0]
-                }
-            } else if (contains(id, '#')) {
-                // id might look like '93LvTKF_jW0#t=1'
-                // and we want '93LvTKF_jW0'
-                id = id.split('#')[0];
-            }
-
-            return id;
-        },
-
-        getTimeFromURL: function (url) {
-            url || (url = '');
-
-            // t=4m20s
-            // returns ['t=4m20s', '4', '20']
-            // t=46s
-            // returns ['t=46s', '46']
-            // t=46
-            // returns ['t=46', '46']
-            var times = url.match(timeRegexp);
-
-            if (!times) {
-                // zero seconds
-                return 0;
-            }
-
-            // assume the first
-            var full = times[0],
-                minutes = times[1],
-                seconds = times[2];
-
-            // t=4m20s
-            if (typeof seconds !== 'undefined') {
-                seconds = parseInt(seconds, 10);
-                minutes = parseInt(minutes, 10);
-
-            // t=4m
-            } else if (contains(full, 'm')) {
-                minutes = parseInt(minutes, 10);
-                seconds = 0;
-
-            // t=4s
-            // t=4
-            } else {
-                seconds = parseInt(minutes, 10);
-                minutes = 0;
-            }
-
-            // in seconds
-            return seconds + (minutes * 60);
-        },
-
-        createPlayer: function (playerVars) {
-            return new YT.Player(this.playerId, {
-                height: this.playerHeight,
-                width: this.playerWidth,
-                videoId: this.videoId,
-                playerVars: playerVars,
-                events: {
-                    onReady: onPlayerReady,
-                    onStateChange: onPlayerStateChange
-                }
-            });
-        },
-
-        loadPlayer: function (playerVars) {
-            if (this.ready && this.playerId && this.videoId) {
-                if (this.player && typeof this.player.destroy === 'function') {
-                    this.player.destroy();
-                }
-
-                this.player = this.createPlayer(playerVars);
-            }
-        }
-    };
-
-    // YT calls callbacks outside of digest cycle
-    function applyBroadcast (event) {
-        $rootScope.$apply(function () {
-            $rootScope.$broadcast(event);
-        });
     }
 
     // from YT.PlayerState
     var stateNames = {
+        '-1': 'unstarted',
         0: 'ended',
         1: 'playing',
         2: 'paused',
@@ -144,78 +23,200 @@ angular.module('youtube-embed', ['ng'])
 
     var eventPrefix = 'youtube.player.';
 
-    function onPlayerReady (event) {
-        applyBroadcast(eventPrefix + 'ready');
+    function getIdFromURL(url) {
+        var id = url.replace(youtubeRegexp, '$1');
+
+        if (contains(id, ';')) {
+            var pieces = id.split(';');
+
+            if (contains(pieces[1], '%')) {
+                // links like this:
+                // "http://www.youtube.com/attribution_link?a=pxa6goHqzaA&amp;u=%2Fwatch%3Fv%3DdPdgx30w9sU%26feature%3Dshare"
+                // have the real query string URI encoded behind a ';'.
+                // at this point, `id is 'pxa6goHqzaA;u=%2Fwatch%3Fv%3DdPdgx30w9sU%26feature%3Dshare'
+                var uriComponent = decodeURIComponent(id.split(';')[1]);
+                id = ('http://youtube.com' + uriComponent)
+                        .replace(youtubeRegexp, '$1');
+            } else {
+                // https://www.youtube.com/watch?v=VbNF9X1waSc&amp;feature=youtu.be
+                // `id` looks like 'VbNF9X1waSc;feature=youtu.be' currently.
+                // strip the ';feature=youtu.be'
+                id = pieces[0];
+            }
+        } else if (contains(id, '#')) {
+            // id might look like '93LvTKF_jW0#t=1'
+            // and we want '93LvTKF_jW0'
+            id = id.split('#')[0];
+        }
+
+        return id;
     }
 
-    function onPlayerStateChange (event) {
-        var state = stateNames[event.data];
-        if (typeof state !== 'undefined') {
-            applyBroadcast(eventPrefix + state);
+    function getTimeFromURL(url) {
+        url = url || '';
+
+        // t=4m20s
+        // returns ['t=4m20s', '4', '20']
+        // t=46s
+        // returns ['t=46s', '46']
+        // t=46
+        // returns ['t=46', '46']
+        var times = url.match(timeRegexp);
+
+        if (!times) {
+            // zero seconds
+            return 0;
         }
-        service.currentState = state;
+
+        // assume the first
+        var full = times[0],
+            minutes = times[1],
+            seconds = times[2];
+
+        // t=4m20s
+        if (typeof seconds !== 'undefined') {
+            seconds = parseInt(seconds, 10);
+            minutes = parseInt(minutes, 10);
+
+        // t=4m
+        } else if (contains(full, 'm')) {
+            minutes = parseInt(minutes, 10);
+            seconds = 0;
+
+        // t=4s
+        // t=4
+        } else {
+            seconds = parseInt(minutes, 10);
+            minutes = 0;
+        }
+
+        // in seconds
+        return seconds + (minutes * 60);
     }
 
     // Inject YouTube's iFrame API
     (function () {
         var tag = document.createElement('script');
-        tag.src = "//www.youtube.com/iframe_api";
+        tag.src = '//www.youtube.com/iframe_api';
         var firstScriptTag = document.getElementsByTagName('script')[0];
         firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
     }());
 
+    var needsDelay = true;
+    var playerCallbacks = [];
+
     // Youtube callback when API is ready
     $window.onYouTubeIframeAPIReady = function () {
         $rootScope.$apply(function () {
-            service.ready = true;
+            // we only get one callback thanks to weird YouTube-ness,
+            // so if a directive's link fn is processed before this CB,
+            // then it gets queued and when execute it now. Otherwise,
+            // we tell future directives to not wait.
+            angular.forEach(playerCallbacks, function (playerCallback) {
+                playerCallback();
+            });
+            needsDelay = false;
         });
     };
 
-    return service;
-}])
-.directive('youtubeVideo', ['$youtube', function ($youtube) {
     return {
         restrict: 'EA',
         scope: {
-            videoId: '=',
-            videoUrl: '=',
-            playerVars: '=',
-            playerHeight: '=',
-            playerWidth: '='
+            videoId: '=?',
+            videoUrl: '=?',
+            player: '=?',
+            playerVars: '=?',
+            playerHeight: '=?',
+            playerWidth: '=?',
         },
         link: function (scope, element, attrs) {
+            // player-id attr > id attr > directive-generated ID
+            var playerId = attrs.playerId || element[0].id || 'unique-youtube-embed-id-' + uniqId++;
+            element[0].id = playerId;
+
             // Attach to element
-            $youtube.playerId = element[0].id;
-            $youtube.playerHeight = scope.playerHeight || 390;
-            $youtube.playerWidth = scope.playerWidth || 640;
+            scope.playerHeight = scope.playerHeight || 390;
+            scope.playerWidth = scope.playerWidth || 640;
+            if (!scope.playerVars) scope.playerVars = {};
 
-            var stopWatchingReady = scope.$watch(
-                function () {
-                    return $youtube.ready
-                        // Wait until one of them is defined...
-                        && (typeof scope.videoUrl !== 'undefined'
-                        ||  typeof scope.videoId !== 'undefined');
-                },
-                function (ready) {
-                    if (ready) {
-                        stopWatchingReady();
+            // YT calls callbacks outside of digest cycle
+            var applyBroadcast = function () {
+                var args = Array.prototype.slice.call(arguments);
+                scope.$apply(function () {
+                    scope.$emit.apply(scope, args);
+                });
+            };
 
-                        // use URL if you've got it
-                        if (typeof scope.videoUrl !== 'undefined') {
-                            scope.$watch('videoUrl', function (url) {
-                                $youtube.setURL(url);
-                                $youtube.loadPlayer(scope.playerVars);
-                            });
+            var onPlayerStateChange = function (event) {
+                var state = stateNames[event.data];
+                if (typeof state !== 'undefined') {
+                    applyBroadcast(eventPrefix + state, scope.player, event);
+                } else {
+                }
+                scope.player.currentState = state;
+            };
 
-                        // otherwise, watch the id
-                        } else {
-                            scope.$watch('videoId', function (id) {
-                                $youtube.videoId = id;
-                                $youtube.loadPlayer(scope.playerVars);
-                            });
-                        }
+            var onPlayerReady = function (event) {
+                if (scope.start) {
+                    // scope.player.seekTo(parseInt(scope.start, 10), true);
+                }
+
+                applyBroadcast(eventPrefix + 'ready', scope.player, event);
+            };
+
+            var createPlayer = function () {
+                var p = new YT.Player(playerId, {
+                    height: scope.playerHeight,
+                    width: scope.playerWidth,
+                    videoId: scope.videoId,
+                    playerVars: scope.playerVars,
+                    events: {
+                        onReady: onPlayerReady,
+                        onStateChange: onPlayerStateChange
                     }
-            });
+                });
+
+                p.id = playerId;
+                return p;
+            };
+
+            var loadPlayer = function () {
+                if (playerId && scope.videoId) {
+                    if (scope.player && typeof scope.player.destroy === 'function') {
+                        scope.player.destroy();
+                    }
+
+                    scope.player = createPlayer();
+                }
+            };
+
+            var setUpPlayer = function () {
+                // use URL if you've got it
+                if (typeof scope.videoUrl !== 'undefined') {
+                    scope.$watch('videoUrl', function (url) {
+                        scope.videoId = getIdFromURL(url);
+
+                        var start = getTimeFromURL(url);
+                        scope.playerVars.start = scope.playerVars.start || start;
+
+                        loadPlayer();
+                    });
+
+                // otherwise, watch the id
+                } else {
+                    scope.$watch('videoId', function (id) {
+                        scope.videoId = id;
+                        loadPlayer();
+                    });
+                }
+            };
+
+            if (needsDelay) {
+                playerCallbacks.push(setUpPlayer);
+            } else {
+                // scope.$apply(setUpPlayer);
+                setUpPlayer();
+            }
         }
     };
 }]);


### PR DESCRIPTION
Ok, this is related to #3 and of course is a substantial "breaks everything" type of change!

I can understand if you want to reject it on that solely based on principle, but here's a bit of what I did:

I did remove the `$youtube` service. I didn't think it was needed. This does mean you don't get those utility functions in your main script and you could bring that back, but I beefed up the directive to handle all the same things, so I argue it's not really needed (but it does change how you interact with it a bit).

So first off, each instance of the directive keeps track of its own player, and this is even attached to the scope if you want to use it in a controller (but it won't be immediately available when the controller is executed. This is weird, but I think acceptable (see some examples below)).

Because of this, you can have multiple independent directives on the page and they play nicely together.

Let's start with this HTML:

``` html
<youtube-video video-id="'E_yan51myNI'"></youtube-video>
<youtube-video video-url="'https://www.youtube.com/watch?v=cq3NYObTthM#t=30'" player-id="banana" player="myPlayer"></youtube-video>
<div>
    Video 2 length: {{ myPlayer.getDuration() }}

    <button ng-click="jump()">Jump!</button>
</div>
```

and this JavaScript (from a controller):

``` javascript
$scope.$on('youtube.player.ready', function (event, player) {
    if (player.id === 'banana') player.playVideo();
});

$scope.$on('youtube.player.paused', function (event, player) {
    console.log('paused', player.id);
});

$scope.jump = function () {
    $scope.myPlayer.seekTo(140, true);
};
```

When the page fully loads, you'll get 2 videos, and the second one, since it has a `playerId` of `banana`, it will begin to play (trigger in the controller) starting at 30 seconds (because of the `#t=30` in the URL).

If you start and then pause the first video, it will have a unique directive-generated ID, since the element itself doesn't have an ID. You can leave an ID off for convenience (i.e. if you just have one video on the page and don't really need it), but obviously if you wanted to actually reference it, you'd be wise to put a `player-id` attribute on the element. It will also fallback to a regular `id` for legacy reasons, but I figured it didn't hurt to be verbose.

You'll also note that there is a button that you can click and it will jump the 2nd video to 140 seconds. This is because I gave it a `player` attribute, so I can access the player and manipulate it directly. This wouldn't be available right away, but would be available by the time most users clicked on the **Jump!** button (you could hide until it was ready if you really wanted to).

Lastly, you'll notice in the event callbacks, it passes in the player, so you can further manipulate the player in the callbacks because the player that trigger the event is passed in (it's 3am, so excuse my circular talk).

One other minor change I made was to make it `$emit` events up from the directives scope (rather than `$broadcast` down from the `$rootScope`). This should make it so that if you have directives in sibling scopes (i.e. two sibling controllers on one page), each other's events won't bleed into each other (untested).

Rather, everything is untested. I do plan on adding some tests... maybe... eventually. But I want to see if you are event interested in the PR or direction at all before I did anything else.

Even if you reject it, we'll probably use this fork in our current project (multiple videos is a must for us). I did think your project had some good stuff in it, and it was worthwhile to refactor your project rather than start from scratch. So thanks for that! =)
