### PR TITLE
Don't Inject API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ $ bower install --save angular-youtube-mb
 Sure! Let me show you.
 
 ```html
-<!-- Include the file -->
+<!-- Include YT library and this directive -->
+<script src="https://www.youtube.com/iframe_api"></script>
 <script src="angular-youtube-embed.js"></script>
 ```
 

--- a/src/angular-youtube-embed.js
+++ b/src/angular-youtube-embed.js
@@ -82,22 +82,23 @@ angular.module('youtube-embed', ['ng'])
         return seconds + (minutes * 60);
     };
 
-    // Inject YouTube's iFrame API
-    (function () {
-        var tag = document.createElement('script');
-        tag.src = 'https://www.youtube.com/iframe_api';
-        var firstScriptTag = document.getElementsByTagName('script')[0];
-        firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
-    }());
-
     Service.ready = false;
 
-    // Youtube callback when API is ready
-    $window.onYouTubeIframeAPIReady = function () {
+    function applyServiceIsReady() {
         $rootScope.$apply(function () {
             Service.ready = true;
         });
     };
+
+    // If the library isn't here at all,
+    if (!YT) {
+        // ...grab on to global callback, in case it's eventually loaded
+        $window.onYouTubeIframeAPIReady = applyServiceIsReady;
+    } else if (YT.loaded) {
+        Service.ready = true;
+    } else {
+        YT.ready(applyServiceIsReady);
+    }
 
     return Service;
 }])

--- a/src/demo/the.html
+++ b/src/demo/the.html
@@ -9,7 +9,8 @@
   <div class="video-wrapper">
 
 <div hljs no-escape language="html">
-&lt;!-- Include the file --&gt;
+&lt;!-- Include YT library and this directive --&gt;
+&lt;script src="https://www.youtube.com/iframe_api"&gt;&lt;/script&gt;
 &lt;script src="angular-youtube-embed.js"&gt;&lt;/script&gt;</div>
 
 <div hljs language="javascript">

--- a/src/index.html
+++ b/src/index.html
@@ -216,6 +216,7 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.22/angular.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.22/angular-route.min.js"></script>
+    <script src="https://www.youtube.com/iframe_api"></script>
     <script src="angular-youtube-embed.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
     <script src="http://pc035860.github.io/angular-highlightjs/angular-highlightjs.min.js"></script>


### PR DESCRIPTION
The YouYube API shouldn't be injected automatically by AYE (angular-youtube-embed).

1- It's no shame to ask people for a `<script>` tag.
2- We might have our own ways to inject scripts.
3- If we also inject the API our own way and it loads before AYE, AYE can't catch the `onYouTubeIframeAPIReady()` call and `Service.ready` stays `false`.