### PR TITLE
added npm and browserify support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ $scope.anotherGoodOne = 'https://www.youtube.com/watch?v=18-xvIjH8T4';
 <youtube-video video-url="anotherGoodOne"></youtube-video>
 ```
 
+## what about browserify?
+
+If you are using browserify, you can install it like this:
+
+```shell
+npm install angular-youtube-mb
+```
+
+and use it in your code like this:
+
+```javascript
+require('angular-youtube-mb');
+```
+
 ## Is that it?
 
 Not quite!

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "author": "Matthew Brandly",
   "license": "MIT",
+  "main": "src/angular-youtube-embed.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/brandly/angular-youtube-embed.git"
@@ -13,6 +14,9 @@
     "postinstall": "bower install",
     "start": "gulp",
     "test": "gulp test"
+  },
+  "dependencies": {
+    "angular": ""
   },
   "devDependencies": {
     "coffee-script": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "homepage": "http://brandly.github.io/angular-youtube-embed/",
   "scripts": {
-    "postinstall": "bower install",
     "start": "gulp",
     "test": "gulp test"
   },

--- a/src/angular-youtube-embed.js
+++ b/src/angular-youtube-embed.js
@@ -1,3 +1,7 @@
+if (!angular && require){
+    var angular = require('angular');
+}
+
 /* global YT */
 angular.module('youtube-embed', ['ng'])
 .service ('youtubeEmbedUtils', ['$window', '$rootScope', function ($window, $rootScope) {


### PR DESCRIPTION
This adds proper dep-tracking, require, and exposes a main, so browserify (and probably webpack and other friends) will work. I also documented it in the README.

I tested this with browserify middleware, using this:
https://gist.github.com/konsumer/0ed26b48e37118d9f89d

I might also recommend removing the `postinstall` line, as it's not needed for a clean npm install like this, and adds a bower dep and a little unneeded compile time.