### PR TITLE
question about getIdFromURL method

### DIFF
--- a/test/unit/get-id-from-url.coffee
+++ b/test/unit/get-id-from-url.coffee
@@ -22,3 +22,13 @@ describe 'getIdFromURL', ->
         url = 'https://www.youtube.com/watch?v=VbNF9X1waSc&amp;feature=youtu.be'
         id = 'VbNF9X1waSc'
         expect(getIdFromURL(url)).toBe id
+
+    it 'should handle http://youtu.be', ->
+        url = 'https://youtu.be/3FY4MRdQOdE'
+        id = '3FY4MRdQOdE'
+        expect(getIdFromURL(url)).toBe id
+
+    it 'should handle "edit" links from video manager page', ->
+        url = 'https://www.youtube.com/edit?o=U&video_id=3k2ZBu3kuiE'
+        id = '3k2ZBu3kuiE'
+        expect(getIdFromURL(url)).toBe id


### PR DESCRIPTION
Hi

Looking at the [unit tests for function 'getIdFromURL'] (https://github.com/brandly/angular-youtube-embed/blob/master/test/unit/get-id-from-url.coffee), some urls are not covered. 

Should we care about those ones:

When you click on "edit" from "video manager" page:
https://www.youtube.com/edit?o=U&video_id=3k2ZBu3kuiE

When you click on share:
https://youtu.be/3FY4MRdQOdE

or share embedded:
<iframe width="560" height="315" src="https://www.youtube.com/embed/3FY4MRdQOdE" frameborder="0" allowfullscreen></iframe> 


My requirements will instruct the user to upload the video and copy the url back to me. I was just thinking if they could copy any of those I mentioned and not the url covered by 'getIdFromURL'.

Leonardo


  