### PR TITLE
Specify YTConfig host as https

### DIFF
--- a/src/angular-youtube-embed.js
+++ b/src/angular-youtube-embed.js
@@ -102,7 +102,7 @@ angular.module('youtube-embed', ['ng'])
 
     return Service;
 }])
-.directive('youtubeVideo', ['youtubeEmbedUtils', function (youtubeEmbedUtils) {
+.directive('youtubeVideo', ['$window', 'youtubeEmbedUtils', function ($window, youtubeEmbedUtils) {
     var uniqId = 1;
 
     // from YT.PlayerState
@@ -116,6 +116,10 @@ angular.module('youtube-embed', ['ng'])
     };
 
     var eventPrefix = 'youtube.player.';
+
+    $window.YTConfig = {
+        host: 'https://www.youtube.com'
+    };
 
     return {
         restrict: 'EA',


### PR DESCRIPTION
Hello, I've encountered the 

```failed to execute 'postMessage' on 'DOMWindow': The target origin provided does not match the recipient window's origin```  error referenced in #62.

I seems that the YouTube iframe API randomly returns `http` or `https`.

If you execute `curl -s http://www.youtube.com/iframe_api | grep http` you can see the following code :

```if (!window['YTConfig']) {var YTConfig = {'host': 'http://www.youtube.com'};}```

So I overrode the `host` option. Now it returns an `https` URL everytime.

Looking forward to feedback !
