### PR TITLE
Avoid destroying old player when video changes

### DIFF
--- a/src/angular-youtube-embed.js
+++ b/src/angular-youtube-embed.js
@@ -192,11 +192,12 @@ angular.module('youtube-embed', [])
 
             function loadPlayer () {
                 if (scope.videoId || scope.playerVars.list) {
-                    if (scope.player && typeof scope.player.destroy === 'function') {
-                        scope.player.destroy();
+                    if (scope.player) {
+                        // player already exists do not replace instead use old player
+                        scope.player.loadVideoById(scope.videoId, 0, 'default');
+                    } else {
+                        scope.player = createPlayer();
                     }
-
-                    scope.player = createPlayer();
                 }
             };
 


### PR DESCRIPTION
This avoids destroying the player when changing the current video. It also prevents the player to stop playing when the video is finished and when user is on a different tab or window. There are a couple of pull requests open for this, but as mentioned in issue #84 this can be solved by simply checking if the player exists before creating a new one. Hopefully we can get this old issue merged soon.